### PR TITLE
Fix repositories for 1.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<repositories>
 		<repository>
 			<id>bukkit-repo</id>
-			<url>http://repo.bukkit.org/content/groups/public/</url>
+			<url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
 		</repository>
 		
 		<repository>
@@ -39,7 +39,7 @@
 		
 		<dependency>
 			<groupId>org.bukkit</groupId>
-			<artifactId>craftbukkit</artifactId>
+			<artifactId>bukkit</artifactId>
 			<version>1.8.3-R0.1-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>


### PR DESCRIPTION
The repositories at bukkit is obsolete, so i changed it for spigot repository where is 1.8.3 data. Now is possible to build that.